### PR TITLE
feat(bets): archived bets section with reactivation

### DIFF
--- a/app/screens/group/GroupScreen.tsx
+++ b/app/screens/group/GroupScreen.tsx
@@ -22,6 +22,7 @@ import { clampDigits, INPUT_LIMITS, isIntInRange, normalizeSingleLineText } from
 import { showAlert } from '../../utils/platformAlert';
 import { getDefaultProfilePicture, resolveProfileImageSource } from '../../utils/profileImage';
 import ActiveBetsSection from './components/ActiveBetsSection';
+import ArchivedBetsSection from './components/ArchivedBetsSection';
 import BetCard from './components/BetCard';
 import DetailedDrinkOverviewCard from './components/DetailedDrinkOverviewCard';
 import DistributionMemberCard from './components/DistributionMemberCard';
@@ -995,6 +996,69 @@ const GroupScreen = () => {
     }
   };
 
+  const handleReactivateBet = async (betIndex: number) => {
+    if (!selectedGroup) return;
+    showAlert(
+      'Gjenåpne bet',
+      'Bettet flyttes tilbake til aktive bets og drinkene som ble tildelt fjernes. Allerede drukne/utdelte drikker reverseres ikke.',
+      [
+        { text: 'Avbryt', style: 'cancel' },
+        {
+          text: 'Gjenåpne',
+          onPress: async () => {
+            try {
+              const db = getFirestore();
+              const groupRef = doc(db, 'groups', selectedGroup.id);
+              const groupSnap = await getDoc(groupRef);
+              if (!groupSnap.exists()) return;
+
+              const groupBets: Bet[] = groupSnap.data().bets || [];
+              const targetBet = groupBets[betIndex];
+              if (!targetBet || !canManageBet(targetBet)) {
+                showAlert('Feil', 'Du har ikke tilgang til å gjenåpne dette bettet.');
+                return;
+              }
+
+              const correctOptionId = targetBet.correctOptionId;
+              const wagers = targetBet.wagers || [];
+
+              await Promise.all(
+                wagers.map(async (wager: BetWager) => {
+                  const userRef = doc(db, 'users', wager.userId);
+                  if (wager.optionId === correctOptionId) {
+                    await updateDoc(
+                      userRef,
+                      new FieldPath('groupDrinkStats', selectedGroup.id, 'drinksToDistribute', wager.drinkType, wager.measureType),
+                      increment(-wager.amount)
+                    );
+                  } else {
+                    await updateDoc(
+                      userRef,
+                      new FieldPath('groupDrinkStats', selectedGroup.id, 'drinksToConsume', wager.drinkType, wager.measureType),
+                      increment(-wager.amount)
+                    );
+                  }
+                })
+              );
+
+              const newBets = [...groupBets];
+              delete newBets[betIndex].correctOptionId;
+              newBets[betIndex].isFinished = false;
+              await updateDoc(groupRef, { bets: newBets });
+              setBets(newBets);
+
+              const updatedLeaderboard = await getLeaderboardData();
+              setLeaderboardData(updatedLeaderboard);
+            } catch (error) {
+              console.error('Error reactivating bet:', error);
+              showAlert('Feil', 'Kunne ikke gjenåpne bet');
+            }
+          },
+        },
+      ]
+    );
+  };
+
   const updateEditBetOption = (idx: number, field: 'name' | 'odds', value: string) => {
     setEditBetOptions(prev => prev.map((opt, i) => (i === idx ? { ...opt, [field]: value } : opt)));
   };
@@ -1434,6 +1498,14 @@ const GroupScreen = () => {
             bets={bets}
             userId={user?.id}
             renderBet={renderBet}
+          />
+
+          <ArchivedBetsSection
+            bets={bets}
+            userId={user?.id}
+            canManageBet={canManageBet}
+            renderBet={renderBet}
+            onReactivate={handleReactivateBet}
           />
 
           {selectedGroup && user && (

--- a/app/screens/group/components/ActiveBetsSection.tsx
+++ b/app/screens/group/components/ActiveBetsSection.tsx
@@ -12,13 +12,15 @@ type ActiveBetsSectionProps = {
 };
 
 const ActiveBetsSection = ({ bets, userId, renderBet }: ActiveBetsSectionProps) => {
+  const activeBets = bets.filter((bet) => !bet.isFinished);
+
   return (
     <View style={groupStyles.betListSection}>
       <View style={[groupStyles.actionCard, groupStyles.betListCard]}>
         <Text style={globalStyles.sectionTitleLeft}>Aktive bets</Text>
         <Text style={[globalStyles.secondaryText, { marginTop: theme.spacing.xs }]}>Plasser bet, følg status og se resultater samlet her.</Text>
         <View style={{ marginTop: theme.spacing.md }}>
-          {bets.map((item) => {
+          {activeBets.map((item) => {
             const isHiddenForCurrentUser = item.hiddenFromUserIds?.includes(userId || '');
             const shouldHideForCurrentUser = isHiddenForCurrentUser && !item.isFinished;
             if (shouldHideForCurrentUser) {
@@ -34,6 +36,7 @@ const ActiveBetsSection = ({ bets, userId, renderBet }: ActiveBetsSectionProps) 
 
             const originalIndex = bets.findIndex((bet) => bet.id === item.id);
             return <View key={item.id}>{renderBet({ item, index: originalIndex })}</View>;
+
           })}
         </View>
       </View>

--- a/app/screens/group/components/ArchivedBetsSection.tsx
+++ b/app/screens/group/components/ArchivedBetsSection.tsx
@@ -1,0 +1,66 @@
+import { Ionicons } from '@expo/vector-icons';
+import React, { useState } from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { groupStyles } from '../../../styles/components/groupStyles';
+import { globalStyles } from '../../../styles/globalStyles';
+import { theme } from '../../../styles/theme';
+import type { Bet } from '../../../types/drinkTypes';
+
+type ArchivedBetsSectionProps = {
+  bets: Bet[];
+  userId?: string;
+  canManageBet: (bet: Bet) => boolean;
+  renderBet: (args: { item: Bet; index: number }) => React.ReactNode;
+  onReactivate: (betIndex: number) => void;
+};
+
+const ArchivedBetsSection = ({ bets, userId: _userId, canManageBet, renderBet, onReactivate }: ArchivedBetsSectionProps) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const archivedBets = bets.filter((bet) => bet.isFinished);
+  if (archivedBets.length === 0) return null;
+
+  return (
+    <View style={groupStyles.betListSection}>
+      <View style={[groupStyles.actionCard, groupStyles.betListCard]}>
+        <TouchableOpacity
+          style={groupStyles.archivedSectionHeader}
+          onPress={() => setExpanded((prev) => !prev)}
+          activeOpacity={0.7}
+        >
+          <Text style={globalStyles.sectionTitleLeft}>
+            Avsluttede bets ({archivedBets.length})
+          </Text>
+          <Ionicons
+            name={expanded ? 'chevron-up' : 'chevron-down'}
+            size={20}
+            color={theme.colors.textSecondary}
+          />
+        </TouchableOpacity>
+
+        {expanded && (
+          <View style={{ marginTop: theme.spacing.md }}>
+            {archivedBets.map((item) => {
+              const originalIndex = bets.findIndex((bet) => bet.id === item.id);
+              return (
+                <View key={item.id}>
+                  {renderBet({ item, index: originalIndex })}
+                  {canManageBet(item) && (
+                    <TouchableOpacity
+                      style={groupStyles.betReactivateRow}
+                      onPress={() => onReactivate(originalIndex)}
+                    >
+                      <Text style={groupStyles.betReactivateText}>Gjenåpne bet ↩</Text>
+                    </TouchableOpacity>
+                  )}
+                </View>
+              );
+            })}
+          </View>
+        )}
+      </View>
+    </View>
+  );
+};
+
+export default ArchivedBetsSection;

--- a/app/styles/components/groupStyles.ts
+++ b/app/styles/components/groupStyles.ts
@@ -896,4 +896,23 @@ export const groupStyles = StyleSheet.create({
     fontSize: theme.fonts.sm,
     fontWeight: '600',
   },
+  archivedSectionHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  betReactivateRow: {
+    marginTop: theme.spacing.sm,
+    marginBottom: theme.spacing.md,
+    paddingTop: theme.spacing.sm,
+    borderTopWidth: 1,
+    borderTopColor: theme.colors.border,
+    alignItems: 'flex-start',
+    marginHorizontal: theme.spacing.md,
+  },
+  betReactivateText: {
+    color: theme.colors.primary,
+    fontSize: theme.fonts.sm,
+    fontWeight: '600',
+  },
 });


### PR DESCRIPTION
## Summary

- Finished bets no longer show in the active bets list — they are filtered out of `ActiveBetsSection`
- New `ArchivedBetsSection` component renders below active bets: collapsible, collapsed by default, shows "Avsluttede bets (N)" with a chevron toggle
- Each archived bet shows a "Gjenåpne bet ↩" button for the bet manager
- Reactivating a bet prompts for confirmation, then reverses the drink stat increments (winners' `drinksToDistribute` and losers' `drinksToConsume` are decremented) before clearing `isFinished` and `correctOptionId`
- Leaderboard refreshes automatically after reactivation