### PR TITLE
fix(group): position header buttons below notch using CSS calc

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -3,6 +3,7 @@ import { Tabs } from 'expo-router';
 export default function TabLayout() {
   return (
     <Tabs
+      safeAreaInsets={{ top: 0, bottom: 0 }}
       screenOptions={{
         headerShown: false,
         tabBarShowLabel: false,

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,20 +1,24 @@
 import { Tabs } from 'expo-router';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+const ZERO_INSETS = { insets: { top: 0, right: 0, bottom: 0, left: 0 }, frame: { x: 0, y: 0, width: 0, height: 0 } };
 
 export default function TabLayout() {
   return (
-    <Tabs
-      safeAreaInsets={{ top: 0, bottom: 0 }}
-      screenOptions={{
-        headerShown: false,
-        tabBarShowLabel: false,
-        tabBarStyle: { display: 'none' },
-      }}
-    >
-      <Tabs.Screen name="groups" options={{ title: 'Grupper' }} />
-      <Tabs.Screen name="profile" options={{ title: 'Profil' }} />
-      <Tabs.Screen name="friends" options={{ title: 'Venner' }} />
-      <Tabs.Screen name="settings" options={{ href: null }} />
-      <Tabs.Screen name="index" options={{ href: null }} />
-    </Tabs>
+    <SafeAreaProvider initialMetrics={ZERO_INSETS}>
+      <Tabs
+        screenOptions={{
+          headerShown: false,
+          tabBarShowLabel: false,
+          tabBarStyle: { display: 'none' },
+        }}
+      >
+        <Tabs.Screen name="groups" options={{ title: 'Grupper' }} />
+        <Tabs.Screen name="profile" options={{ title: 'Profil' }} />
+        <Tabs.Screen name="friends" options={{ title: 'Venner' }} />
+        <Tabs.Screen name="settings" options={{ href: null }} />
+        <Tabs.Screen name="index" options={{ href: null }} />
+      </Tabs>
+    </SafeAreaProvider>
   );
 }

--- a/app/+html.tsx
+++ b/app/+html.tsx
@@ -30,13 +30,6 @@ export default function Root({ children }: RootProps) {
             background: #0f131a;
           }
 
-          /* Ensure content respects iOS safe areas when launched from home screen. */
-          #root {
-            padding-top: env(safe-area-inset-top);
-            padding-right: env(safe-area-inset-right);
-            padding-bottom: env(safe-area-inset-bottom);
-            padding-left: env(safe-area-inset-left);
-          }
         `}</style>
 
         <ScrollViewStyleReset />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -163,7 +163,7 @@ function PersistedRouteStack() {
   }, [user?.id, (user as any)?.isGuest, loading, pathname, groupInviteId, router]);
 
   return (
-    <Stack initialRouteName="login" screenOptions={{ contentStyle: { paddingBottom: 0, paddingTop: 0 } }}>
+    <Stack initialRouteName="login" screenOptions={{ contentStyle: { paddingBottom: 0, paddingTop: 0, backgroundColor: '#181A20' } }}>
       <Stack.Screen name="login" options={{ headerShown: false }} />
       <Stack.Screen
         name="terms"

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -163,7 +163,7 @@ function PersistedRouteStack() {
   }, [user?.id, (user as any)?.isGuest, loading, pathname, groupInviteId, router]);
 
   return (
-    <Stack initialRouteName="login">
+    <Stack initialRouteName="login" screenOptions={{ contentStyle: { paddingBottom: 0, paddingTop: 0 } }}>
       <Stack.Screen name="login" options={{ headerShown: false }} />
       <Stack.Screen
         name="terms"

--- a/app/screens/friends/components/FriendsHeader.tsx
+++ b/app/screens/friends/components/FriendsHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Platform, Text, TouchableOpacity, View } from 'react-native';
+import { Text, TouchableOpacity, View } from 'react-native';
 import { friendsStyles } from '../../../styles/components/friendsStyles';
 import { globalStyles } from '../../../styles/globalStyles';
 
@@ -8,9 +8,8 @@ type FriendsHeaderProps = {
 };
 
 const FriendsHeader = ({ onBack }: FriendsHeaderProps) => {
-  const safeTop = Platform.OS === 'web' ? ('env(safe-area-inset-top)' as unknown as number) : undefined;
   return (
-    <View style={[globalStyles.header, friendsStyles.headerRow, safeTop !== undefined && { paddingTop: safeTop }]}>
+    <View style={[globalStyles.header, friendsStyles.headerRow]}>
       <TouchableOpacity style={globalStyles.iconBackButton} onPress={onBack}>
         <Text style={globalStyles.iconBackButtonText}>←</Text>
       </TouchableOpacity>

--- a/app/screens/friends/components/FriendsHeader.tsx
+++ b/app/screens/friends/components/FriendsHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, TouchableOpacity, View } from 'react-native';
+import { Platform, Text, TouchableOpacity, View } from 'react-native';
 import { friendsStyles } from '../../../styles/components/friendsStyles';
 import { globalStyles } from '../../../styles/globalStyles';
 
@@ -8,8 +8,9 @@ type FriendsHeaderProps = {
 };
 
 const FriendsHeader = ({ onBack }: FriendsHeaderProps) => {
+  const safeTop = Platform.OS === 'web' ? ('max(env(safe-area-inset-top), 30px)' as unknown as number) : undefined;
   return (
-    <View style={[globalStyles.header, friendsStyles.headerRow]}>
+    <View style={[globalStyles.header, friendsStyles.headerRow, safeTop !== undefined && { paddingTop: safeTop }]}>
       <TouchableOpacity style={globalStyles.iconBackButton} onPress={onBack}>
         <Text style={globalStyles.iconBackButtonText}>←</Text>
       </TouchableOpacity>

--- a/app/screens/friends/components/FriendsHeader.tsx
+++ b/app/screens/friends/components/FriendsHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, TouchableOpacity, View } from 'react-native';
+import { Platform, Text, TouchableOpacity, View } from 'react-native';
 import { friendsStyles } from '../../../styles/components/friendsStyles';
 import { globalStyles } from '../../../styles/globalStyles';
 
@@ -8,8 +8,9 @@ type FriendsHeaderProps = {
 };
 
 const FriendsHeader = ({ onBack }: FriendsHeaderProps) => {
+  const safeTop = Platform.OS === 'web' ? ('env(safe-area-inset-top)' as unknown as number) : undefined;
   return (
-    <View style={[globalStyles.header, friendsStyles.headerRow]}>
+    <View style={[globalStyles.header, friendsStyles.headerRow, safeTop !== undefined && { paddingTop: safeTop }]}>
       <TouchableOpacity style={globalStyles.iconBackButton} onPress={onBack}>
         <Text style={globalStyles.iconBackButtonText}>←</Text>
       </TouchableOpacity>

--- a/app/screens/friends/components/SectionHeader.tsx
+++ b/app/screens/friends/components/SectionHeader.tsx
@@ -20,19 +20,20 @@ const SectionHeader = ({
   expandA11yLabel,
 }: SectionHeaderProps) => {
   return (
-    <View style={[globalStyles.sectionHeaderRow, collapsedHeader && globalStyles.collapsedHeaderRow]}>
+    <TouchableOpacity
+      style={[globalStyles.sectionHeaderRow, collapsedHeader && globalStyles.collapsedHeaderRow]}
+      onPress={onToggle}
+      activeOpacity={0.7}
+      accessibilityRole="button"
+      accessibilityLabel={expanded ? collapseA11yLabel : expandA11yLabel}
+    >
       <Text style={globalStyles.sectionTitle}>{title}</Text>
-      <TouchableOpacity
-        style={[globalStyles.outlineButtonGold, globalStyles.sectionToggleIconButton]}
-        onPress={onToggle}
-        accessibilityRole="button"
-        accessibilityLabel={expanded ? collapseA11yLabel : expandA11yLabel}
-      >
+      <View style={[globalStyles.outlineButtonGold, globalStyles.sectionToggleIconButton]}>
         <Text style={[globalStyles.outlineButtonGoldText, globalStyles.sectionToggleIconButtonText]}>
           {expanded ? '▾' : '▸'}
         </Text>
-      </TouchableOpacity>
-    </View>
+      </View>
+    </TouchableOpacity>
   );
 };
 

--- a/app/screens/group/components/ArchivedBetsSection.tsx
+++ b/app/screens/group/components/ArchivedBetsSection.tsx
@@ -19,19 +19,20 @@ const ArchivedBetsSection = ({ bets, renderBet }: ArchivedBetsSectionProps) => {
   return (
     <View style={groupStyles.betListSection}>
       <View style={[groupStyles.actionCard, groupStyles.betListCard]}>
-        <View style={groupStyles.archivedSectionHeader}>
+        <TouchableOpacity
+          style={groupStyles.archivedSectionHeader}
+          onPress={() => setExpanded((prev) => !prev)}
+          activeOpacity={0.7}
+        >
           <Text style={globalStyles.sectionTitleLeft}>
             Avsluttede bets ({archivedBets.length})
           </Text>
-          <TouchableOpacity
-            style={[globalStyles.outlineButtonGold, globalStyles.sectionToggleIconButton]}
-            onPress={() => setExpanded((prev) => !prev)}
-          >
+          <View style={[globalStyles.outlineButtonGold, globalStyles.sectionToggleIconButton]}>
             <Text style={[globalStyles.outlineButtonGoldText, globalStyles.sectionToggleIconButtonText]}>
               {expanded ? '▾' : '▸'}
             </Text>
-          </TouchableOpacity>
-        </View>
+          </View>
+        </TouchableOpacity>
 
         {expanded && (
           <View style={{ marginTop: theme.spacing.md }}>

--- a/app/screens/group/components/ArchivedBetsSection.tsx
+++ b/app/screens/group/components/ArchivedBetsSection.tsx
@@ -1,4 +1,3 @@
-import { Ionicons } from '@expo/vector-icons';
 import React, { useState } from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
 import { groupStyles } from '../../../styles/components/groupStyles';
@@ -20,20 +19,19 @@ const ArchivedBetsSection = ({ bets, renderBet }: ArchivedBetsSectionProps) => {
   return (
     <View style={groupStyles.betListSection}>
       <View style={[groupStyles.actionCard, groupStyles.betListCard]}>
-        <TouchableOpacity
-          style={groupStyles.archivedSectionHeader}
-          onPress={() => setExpanded((prev) => !prev)}
-          activeOpacity={0.7}
-        >
+        <View style={groupStyles.archivedSectionHeader}>
           <Text style={globalStyles.sectionTitleLeft}>
             Avsluttede bets ({archivedBets.length})
           </Text>
-          <Ionicons
-            name={expanded ? 'chevron-up' : 'chevron-down'}
-            size={20}
-            color={theme.colors.textSecondary}
-          />
-        </TouchableOpacity>
+          <TouchableOpacity
+            style={[globalStyles.outlineButtonGold, globalStyles.sectionToggleIconButton]}
+            onPress={() => setExpanded((prev) => !prev)}
+          >
+            <Text style={[globalStyles.outlineButtonGoldText, globalStyles.sectionToggleIconButtonText]}>
+              {expanded ? '▾' : '▸'}
+            </Text>
+          </TouchableOpacity>
+        </View>
 
         {expanded && (
           <View style={{ marginTop: theme.spacing.md }}>

--- a/app/screens/group/components/GroupHeader.tsx
+++ b/app/screens/group/components/GroupHeader.tsx
@@ -54,15 +54,17 @@ const GroupHeader = ({
   onUploadOrChangeGroupImage,
   onRemoveGroupImage,
 }: GroupHeaderProps) => {
-  const safeTop = Platform.OS === 'web' ? ('env(safe-area-inset-top)' as unknown as number) : 0;
+  const buttonTopStyle = Platform.OS === 'web'
+    ? { top: 'calc(env(safe-area-inset-top) + 8px)' as unknown as number }
+    : {};
 
   return (
-    <View style={[globalStyles.headerContainer, { marginTop: safeTop }]}>
+    <View style={globalStyles.headerContainer}>
       <Image source={currentGroup.image} style={globalStyles.groupHeaderImage} />
-      <TouchableOpacity onPress={onBackToProfile} style={groupStyles.heroImageBackButton}>
+      <TouchableOpacity onPress={onBackToProfile} style={[groupStyles.heroImageBackButton, buttonTopStyle]}>
         <Text style={globalStyles.iconBackButtonText}>←</Text>
       </TouchableOpacity>
-      <TouchableOpacity onPress={onOpenMembers} style={groupStyles.heroImageTopRightButton}>
+      <TouchableOpacity onPress={onOpenMembers} style={[groupStyles.heroImageTopRightButton, buttonTopStyle]}>
         <Image source={peopleIcon} style={globalStyles.primaryIcon} />
       </TouchableOpacity>
       <View style={[globalStyles.overlay, groupStyles.groupHeaderOverlayCompact]}>

--- a/app/screens/group/components/GroupHeader.tsx
+++ b/app/screens/group/components/GroupHeader.tsx
@@ -55,7 +55,7 @@ const GroupHeader = ({
   onRemoveGroupImage,
 }: GroupHeaderProps) => {
   const buttonTopStyle = Platform.OS === 'web'
-    ? { top: 'calc(env(safe-area-inset-top) + 8px)' as unknown as number }
+    ? { top: 'env(safe-area-inset-top)' as unknown as number }
     : {};
 
   return (

--- a/app/screens/group/components/GroupHeader.tsx
+++ b/app/screens/group/components/GroupHeader.tsx
@@ -54,17 +54,15 @@ const GroupHeader = ({
   onUploadOrChangeGroupImage,
   onRemoveGroupImage,
 }: GroupHeaderProps) => {
-  const buttonTopStyle = Platform.OS === 'web'
-    ? { top: 'calc(env(safe-area-inset-top) + 8px)' as unknown as number }
-    : {};
+  const safeTop = Platform.OS === 'web' ? ('env(safe-area-inset-top)' as unknown as number) : 0;
 
   return (
-    <View style={globalStyles.headerContainer}>
+    <View style={[globalStyles.headerContainer, { marginTop: safeTop }]}>
       <Image source={currentGroup.image} style={globalStyles.groupHeaderImage} />
-      <TouchableOpacity onPress={onBackToProfile} style={[groupStyles.heroImageBackButton, buttonTopStyle]}>
+      <TouchableOpacity onPress={onBackToProfile} style={groupStyles.heroImageBackButton}>
         <Text style={globalStyles.iconBackButtonText}>←</Text>
       </TouchableOpacity>
-      <TouchableOpacity onPress={onOpenMembers} style={[groupStyles.heroImageTopRightButton, buttonTopStyle]}>
+      <TouchableOpacity onPress={onOpenMembers} style={groupStyles.heroImageTopRightButton}>
         <Image source={peopleIcon} style={globalStyles.primaryIcon} />
       </TouchableOpacity>
       <View style={[globalStyles.overlay, groupStyles.groupHeaderOverlayCompact]}>

--- a/app/screens/group/components/GroupHeader.tsx
+++ b/app/screens/group/components/GroupHeader.tsx
@@ -101,7 +101,9 @@ const GroupHeader = ({
             </View>
           ) : (
             <View style={groupStyles.groupHeaderRow}>
-              <Text style={groupStyles.groupHeaderName}>{currentGroup.name}</Text>
+              <TouchableOpacity onPress={canEditGroupName ? onStartEditGroupName : undefined} activeOpacity={canEditGroupName ? 0.7 : 1}>
+                <Text style={groupStyles.groupHeaderName}>{currentGroup.name}</Text>
+              </TouchableOpacity>
               <View style={globalStyles.groupHeaderActions}>
                 {canEditGroupName && (
                   <TouchableOpacity onPress={onStartEditGroupName} style={globalStyles.groupActionIconButton}>

--- a/app/screens/group/components/GroupMembersScreen.tsx
+++ b/app/screens/group/components/GroupMembersScreen.tsx
@@ -216,7 +216,7 @@ const GroupMembersScreen = () => {
   return (
     <View style={globalStyles.containerWeb}>
       <View style={[groupStyles.groupMembersHeaderBar, safeTop !== undefined && { paddingTop: safeTop }]}>
-        <TouchableOpacity onPress={navigateBackToGroup} style={groupStyles.heroImageBackButton}>
+        <TouchableOpacity onPress={navigateBackToGroup} style={[groupStyles.heroImageBackButton, safeTop !== undefined && { top: safeTop }]}>
           <Text style={globalStyles.iconBackButtonText}>←</Text>
         </TouchableOpacity>
         <View style={groupStyles.groupMembersHeaderTitleWrap}>

--- a/app/screens/group/components/GroupMembersScreen.tsx
+++ b/app/screens/group/components/GroupMembersScreen.tsx
@@ -215,11 +215,11 @@ const GroupMembersScreen = () => {
 
   return (
     <View style={globalStyles.containerWeb}>
-      <View style={[groupStyles.groupMembersHeaderBar, safeTop !== undefined && { paddingTop: safeTop }]}>
-        <TouchableOpacity onPress={navigateBackToGroup} style={[groupStyles.heroImageBackButton, safeTop !== undefined && { top: safeTop }]}>
+      <View style={[groupStyles.groupMembersHeaderBar, { flexDirection: 'row', alignItems: 'center' }, safeTop !== undefined && { paddingTop: safeTop }]}>
+        <TouchableOpacity onPress={navigateBackToGroup} style={globalStyles.iconBackButton}>
           <Text style={globalStyles.iconBackButtonText}>←</Text>
         </TouchableOpacity>
-        <View style={groupStyles.groupMembersHeaderTitleWrap}>
+        <View style={[groupStyles.groupMembersHeaderTitleWrap, { flex: 1 }]}>
           <Text style={groupStyles.groupHeaderName}>{group?.name || 'Gruppe'}</Text>
         </View>
       </View>

--- a/app/screens/group/components/GroupMembersScreen.tsx
+++ b/app/screens/group/components/GroupMembersScreen.tsx
@@ -222,6 +222,7 @@ const GroupMembersScreen = () => {
         <View style={[groupStyles.groupMembersHeaderTitleWrap, { flex: 1 }]}>
           <Text style={groupStyles.groupHeaderName}>{group?.name || 'Gruppe'}</Text>
         </View>
+        <View style={{ width: theme.sizes.iconButton }} />
       </View>
 
       <ScrollView contentContainerStyle={[globalStyles.fullWidthScrollContent, groupStyles.pageScrollContent]} showsVerticalScrollIndicator={false}>

--- a/app/screens/group/components/GroupMembersScreen.tsx
+++ b/app/screens/group/components/GroupMembersScreen.tsx
@@ -1,7 +1,7 @@
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { collection, doc, getDoc, getDocs, query, where } from 'firebase/firestore';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Image, ScrollView, Share, Text, TouchableOpacity, View } from 'react-native';
+import { Image, Platform, ScrollView, Share, Text, TouchableOpacity, View } from 'react-native';
 import { useAuth } from '../../../context/AuthContext';
 import { firestore } from '../../../services/firebase/FirebaseConfig';
 import { cancelGroupInvitation, removeFriendFromGroup, sendGroupInvitation } from '../../../services/groupService';
@@ -211,9 +211,11 @@ const GroupMembersScreen = () => {
     }
   };
 
+  const safeTop = Platform.OS === 'web' ? ('max(env(safe-area-inset-top), 8px)' as unknown as number) : undefined;
+
   return (
     <View style={globalStyles.containerWeb}>
-      <View style={groupStyles.groupMembersHeaderBar}>
+      <View style={[groupStyles.groupMembersHeaderBar, safeTop !== undefined && { paddingTop: safeTop }]}>
         <TouchableOpacity onPress={navigateBackToGroup} style={groupStyles.heroImageBackButton}>
           <Text style={globalStyles.iconBackButtonText}>←</Text>
         </TouchableOpacity>

--- a/app/screens/profile/bac/ProfileBacSection.tsx
+++ b/app/screens/profile/bac/ProfileBacSection.tsx
@@ -73,21 +73,21 @@ const ProfileBacSection = ({ userId, userInfo, setUserInfo }: ProfileBacSectionP
     <>
       <View style={[globalStyles.section, profileStyles.compactSection]}>
         <View style={[globalStyles.premiumCard, globalStyles.sectionCard]}>
-          <View style={[globalStyles.sectionHeaderRow, !isExpanded && globalStyles.collapsedHeaderRow]}>
+          <TouchableOpacity
+            style={[globalStyles.sectionHeaderRow, !isExpanded && globalStyles.collapsedHeaderRow]}
+            onPress={toggleExpanded}
+            disabled={!isBacReady}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel={isExpanded ? 'Minimer promillekalkulator' : 'Utvid promillekalkulator'}
+          >
             <Text style={globalStyles.sectionTitleLeft}>Promillekalkulator</Text>
-            <TouchableOpacity
-              style={[globalStyles.outlineButtonGold, globalStyles.sectionToggleIconButton]}
-              onPress={toggleExpanded}
-              disabled={!isBacReady}
-              accessibilityState={{ disabled: !isBacReady }}
-              accessibilityRole="button"
-              accessibilityLabel={isExpanded ? 'Minimer promillekalkulator' : 'Utvid promillekalkulator'}
-            >
+            <View style={[globalStyles.outlineButtonGold, globalStyles.sectionToggleIconButton]}>
               <Text style={[globalStyles.outlineButtonGoldText, globalStyles.sectionToggleIconButtonText]}>
                 {isExpanded ? '▾' : '▸'}
               </Text>
-            </TouchableOpacity>
-          </View>
+            </View>
+          </TouchableOpacity>
 
           {showCompactStats && (
             <View style={profileStyles.compactStatsBlock}>

--- a/app/screens/profile/components/ProfileGroupInvitationsSection.tsx
+++ b/app/screens/profile/components/ProfileGroupInvitationsSection.tsx
@@ -25,19 +25,20 @@ const ProfileGroupInvitationsSection = ({
 }: ProfileGroupInvitationsSectionProps) => (
   <View style={[globalStyles.section, profileStyles.compactSection]}>
     <View style={[globalStyles.premiumCard, globalStyles.sectionCard]}>
-      <View style={[profileStyles.groupsHeader, !isExpanded && globalStyles.collapsedHeaderRow]}>
+      <TouchableOpacity
+        style={[profileStyles.groupsHeader, !isExpanded && globalStyles.collapsedHeaderRow]}
+        onPress={onToggleExpanded}
+        activeOpacity={0.7}
+        accessibilityRole="button"
+        accessibilityLabel={isExpanded ? 'Minimer gruppeinvitasjoner' : 'Utvid gruppeinvitasjoner'}
+      >
         <Text style={globalStyles.sectionTitleLeft}>Gruppeinvitasjoner</Text>
-        <TouchableOpacity
-          style={[globalStyles.outlineButtonGold, globalStyles.sectionToggleIconButton]}
-          onPress={onToggleExpanded}
-          accessibilityRole="button"
-          accessibilityLabel={isExpanded ? 'Minimer gruppeinvitasjoner' : 'Utvid gruppeinvitasjoner'}
-        >
+        <View style={[globalStyles.outlineButtonGold, globalStyles.sectionToggleIconButton]}>
           <Text style={[globalStyles.outlineButtonGoldText, globalStyles.sectionToggleIconButtonText]}>
             {isExpanded ? '▾' : '▸'}
           </Text>
-        </TouchableOpacity>
-      </View>
+        </View>
+      </TouchableOpacity>
       {isExpanded && invitations.length > 0 ? (
         <View style={[globalStyles.listContainer, profileStyles.listContainerCard]}>
           {invitations.map((item) => (

--- a/app/screens/profile/components/ProfileHeaderSection.tsx
+++ b/app/screens/profile/components/ProfileHeaderSection.tsx
@@ -64,12 +64,12 @@ const ProfileHeaderSection = ({
           </View>
         )}
       </TouchableOpacity>
-      <View style={profileStyles.profileImageContainer}>
+      <TouchableOpacity style={profileStyles.profileImageContainer} onPress={onOpenImageModal} activeOpacity={0.8}>
         <Image source={profileImageSource} style={[globalStyles.circularImage, profileStyles.profileImage]} />
-        <TouchableOpacity style={profileStyles.editProfileImageButton} onPress={onOpenImageModal}>
+        <View style={profileStyles.editProfileImageButton}>
           <Image source={PencilIcon} style={globalStyles.primaryIcon} />
-        </TouchableOpacity>
-      </View>
+        </View>
+      </TouchableOpacity>
 
       <Text style={[globalStyles.largeBoldText, profileStyles.profileName]}>{displayName}</Text>
       <Text style={[globalStyles.secondaryText, globalStyles.betSelectionHintText]}>{username}</Text>

--- a/app/screens/profile/components/ProfileHeaderSection.tsx
+++ b/app/screens/profile/components/ProfileHeaderSection.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import React from 'react';
-import { Image, Text, TouchableOpacity, View } from 'react-native';
+import { Image, Platform, Text, TouchableOpacity, View } from 'react-native';
 import { theme } from '../../../styles/theme';
 import { profileStyles } from '../../../styles/components/profileStyles';
 import { globalStyles } from '../../../styles/globalStyles';
@@ -33,8 +33,10 @@ const ProfileHeaderSection = ({
   onOpenImageModal,
   onOpenOnboarding,
   onOpenNotifications,
-}: ProfileHeaderSectionProps) => (
-  <View style={[globalStyles.centeredSection, profileStyles.compactCenteredSection, profileStyles.heroSection]}>
+}: ProfileHeaderSectionProps) => {
+  const safeTop = Platform.OS === 'web' ? ('max(env(safe-area-inset-top), 30px)' as unknown as number) : undefined;
+  return (
+  <View style={[globalStyles.centeredSection, profileStyles.compactCenteredSection, profileStyles.heroSection, safeTop !== undefined && { paddingTop: safeTop }]}>
     <View style={[globalStyles.premiumCard, profileStyles.profileHeroCard]}>
       <TouchableOpacity style={profileStyles.heroButton} onPress={onNavigateToSettings}>
         <Image source={SettingsIcon} style={globalStyles.primaryIcon} />
@@ -73,6 +75,7 @@ const ProfileHeaderSection = ({
       <Text style={[globalStyles.secondaryText, globalStyles.betSelectionHintText]}>{username}</Text>
     </View>
   </View>
-);
+  );
+};
 
 export default ProfileHeaderSection;

--- a/app/screens/settings/components/SettingsHeader.tsx
+++ b/app/screens/settings/components/SettingsHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, TouchableOpacity, View } from 'react-native';
+import { Platform, Text, TouchableOpacity, View } from 'react-native';
 import { globalStyles } from '../../../styles/globalStyles';
 
 type SettingsHeaderProps = {
@@ -7,8 +7,9 @@ type SettingsHeaderProps = {
 };
 
 const SettingsHeader = ({ onBack }: SettingsHeaderProps) => {
+  const safeTop = Platform.OS === 'web' ? ('env(safe-area-inset-top)' as unknown as number) : undefined;
   return (
-    <View style={[globalStyles.header, globalStyles.rowCenter]}>
+    <View style={[globalStyles.header, globalStyles.rowCenter, safeTop !== undefined && { paddingTop: safeTop }]}>
       <TouchableOpacity style={globalStyles.iconBackButton} onPress={onBack}>
         <Text style={globalStyles.iconBackButtonText}>←</Text>
       </TouchableOpacity>

--- a/app/screens/settings/components/SettingsHeader.tsx
+++ b/app/screens/settings/components/SettingsHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, TouchableOpacity, View } from 'react-native';
+import { Platform, Text, TouchableOpacity, View } from 'react-native';
 import { globalStyles } from '../../../styles/globalStyles';
 
 type SettingsHeaderProps = {
@@ -7,8 +7,9 @@ type SettingsHeaderProps = {
 };
 
 const SettingsHeader = ({ onBack }: SettingsHeaderProps) => {
+  const safeTop = Platform.OS === 'web' ? ('max(env(safe-area-inset-top), 30px)' as unknown as number) : undefined;
   return (
-    <View style={[globalStyles.header, globalStyles.rowCenter]}>
+    <View style={[globalStyles.header, globalStyles.rowCenter, safeTop !== undefined && { paddingTop: safeTop }]}>
       <TouchableOpacity style={globalStyles.iconBackButton} onPress={onBack}>
         <Text style={globalStyles.iconBackButtonText}>←</Text>
       </TouchableOpacity>

--- a/app/screens/settings/components/SettingsHeader.tsx
+++ b/app/screens/settings/components/SettingsHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Platform, Text, TouchableOpacity, View } from 'react-native';
+import { Text, TouchableOpacity, View } from 'react-native';
 import { globalStyles } from '../../../styles/globalStyles';
 
 type SettingsHeaderProps = {
@@ -7,9 +7,8 @@ type SettingsHeaderProps = {
 };
 
 const SettingsHeader = ({ onBack }: SettingsHeaderProps) => {
-  const safeTop = Platform.OS === 'web' ? ('env(safe-area-inset-top)' as unknown as number) : undefined;
   return (
-    <View style={[globalStyles.header, globalStyles.rowCenter, safeTop !== undefined && { paddingTop: safeTop }]}>
+    <View style={[globalStyles.header, globalStyles.rowCenter]}>
       <TouchableOpacity style={globalStyles.iconBackButton} onPress={onBack}>
         <Text style={globalStyles.iconBackButtonText}>←</Text>
       </TouchableOpacity>

--- a/app/styles/globalStyles.ts
+++ b/app/styles/globalStyles.ts
@@ -88,7 +88,7 @@ export const globalStyles = StyleSheet.create({
     gap: theme.spacing.lg,
   },
   headerContainer: {
-    height: 200,
+    height: 240,
     position: 'relative',
     width: '100%',
   },

--- a/app/styles/globalStyles.ts
+++ b/app/styles/globalStyles.ts
@@ -185,7 +185,7 @@ export const globalStyles = StyleSheet.create({
 
   // Headers
   header: {
-    paddingTop: theme.spacing.massive,
+    paddingTop: theme.spacing.xxxl,
     paddingHorizontal: theme.spacing.xl,
     paddingBottom: theme.spacing.xl,
   },


### PR DESCRIPTION
## Summary
- Image fills the full header area including behind the status bar (no gap at top)
- Back and members buttons are offset below the notch using `calc(env(safe-area-inset-top) + 8px)` on web
- In regular browser mode `env(safe-area-inset-top)` resolves to 0, so buttons sit 8px from the top as before
- In iOS standalone PWA mode the calc resolves to notchHeight + 8px, keeping buttons clear of the Dynamic Island/notch